### PR TITLE
uaddMag() error when increasing "len" from 1 to 2

### DIFF
--- a/src/main/java/org/huldra/math/BigInt.java
+++ b/src/main/java/org/huldra/math/BigInt.java
@@ -814,6 +814,7 @@ public class BigInt extends Number implements Comparable<BigInt>
 		carry >>>= 32;
 		carry = (dig[1]&mask) + ah + carry;
 		dig[1] = (int)carry;
+		if(len==1 && dig[1]!=0) len=2; // KL(m) change (new line)
 		if((carry>>32)!=0)
 		{
 			int i = 2;


### PR DESCRIPTION
While adding and "len" should cross the barrier 1->2 this actually does not happen.
Instead "len" remains one. 
This fix tries to solve it.