### PR TITLE
#20 Add missing license information to pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# VS Code
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,13 @@
   <name>BigInt</name>
   <url>http://maven.apache.org</url>
   <description>A class to beat the crap out of BigInteger!</description>
+  <licenses>
+    <license>
+      <name>BSD-2-Clause-Views</name>
+      <url>https://raw.githubusercontent.com/bwakell/Huldra/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Just an update to the POM to include the license information for any future releases. Tools like the [license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/) flag BigInt as a warning for having no license at current.

The license name used the SPDX identifier as the name as recommended by Maven:
- https://spdx.org/licenses/BSD-2-Clause-Views.html
- https://maven.apache.org/pom.html#licenses

The URL uses your main branches LICENSE file, so it includes your actual copyright info.

Issue #20 